### PR TITLE
Not found business logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All noteable changes to functionality are documented in this file.
 All dates in this log are in [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) format and represent the
 date the release was prepared, **not** the date of release.
 
+## 0.3.0 2021-06-30
+
+### Changed
+
+1. Added 404 as business logic exception 
+
 ## 0.2.0 - 2021-06-30
 
 ### Changed

--- a/src/Client/BusinessLogicExceptionFactory.php
+++ b/src/Client/BusinessLogicExceptionFactory.php
@@ -16,9 +16,10 @@ class BusinessLogicExceptionFactory
      * @param string $errorCode
      * @param array $context
      * @param string $responseBody
+     * @param int $statusCode
      * @return BusinessLogicException
      */
-    public function make(string $errorCode, array $context, string $responseBody): BusinessLogicException
+    public function make(string $errorCode, array $context, string $responseBody, int $statusCode): BusinessLogicException
     {
         switch ($errorCode) {
             case Errors::INSUFFICIENT_STOCK:
@@ -26,20 +27,21 @@ class BusinessLogicExceptionFactory
             case Errors::MISSING_SKU:
                 return $this->createMissingSkuException($context, $responseBody);
             case Errors::NO_MATCHING_ORDER:
-                return $this->createNoMatchingOrderException($context, $responseBody);
+                return $this->createNoMatchingOrderException($context, $responseBody, $statusCode);
             default:
-                return new BusinessLogicException($errorCode, $context, $responseBody);
+                return new BusinessLogicException($errorCode, $context, $responseBody, $statusCode);
         }
     }
 
     /**
      * @param array $context
      * @param string $responseBody
+     * @param int $statusCode
      * @return NoMatchingOrderException
      */
-    protected function createNoMatchingOrderException(array $context, string $responseBody): NoMatchingOrderException
+    protected function createNoMatchingOrderException(array $context, string $responseBody, int $statusCode): NoMatchingOrderException
     {
-        return new NoMatchingOrderException($context, $responseBody);
+        return new NoMatchingOrderException($context, $responseBody, $statusCode);
     }
 
     /**

--- a/src/Client/ErrorHandler.php
+++ b/src/Client/ErrorHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Huboo\Client;
 
-use GuzzleHttp\Psr7\Response;
 use Huboo\Exceptions\UnauthorizedException;
 use Huboo\Exceptions\UnprocessableRequestException;
 use Huboo\Exceptions\ValidationException;
@@ -32,9 +31,9 @@ class ErrorHandler
     public function handle(ResponseInterface $response)
     {
         $responseBody = $response->getBody()->getContents();
-        if ($response->getStatusCode() === 400) {
+        if ($response->getStatusCode() === 400 || $response->getStatusCode() === 404) {
             $responseData = $this->parseResponseBody($responseBody);
-            throw $this->exceptionFactory->make($responseData['code'], $responseData['context'], $responseBody);
+            throw $this->exceptionFactory->make($responseData['code'], $responseData['context'], $responseBody, $response->getStatusCode());
         } elseif ($response->getStatusCode() === 422) {
             $responseData = $this->parseResponseBody($responseBody);
             throw new ValidationException($responseData['errors'], $responseBody);

--- a/src/Exceptions/BusinessLogicException.php
+++ b/src/Exceptions/BusinessLogicException.php
@@ -6,22 +6,41 @@ namespace Huboo\Exceptions;
 
 class BusinessLogicException extends UnprocessableRequestException
 {
+    /**
+     * @var string
+     */
     protected string $errorCode;
 
+    /**
+     * @var array
+     */
     protected array $context;
 
-    public function __construct(string $errorCode, array $context, string $responseBody)
+    /**
+     * BusinessLogicException constructor.
+     * @param string $errorCode
+     * @param array $context
+     * @param string $responseBody
+     * @param int $statusCode
+     */
+    public function __construct(string $errorCode, array $context, string $responseBody, int $statusCode)
     {
-        parent::__construct('A business logic exception occurred', 400, $responseBody);
+        parent::__construct('A business logic exception occurred', $statusCode, $responseBody);
         $this->errorCode = $errorCode;
         $this->context = $context;
     }
 
+    /**
+     * @return array
+     */
     public function getContext(): array
     {
         return $this->context;
     }
 
+    /**
+     * @return string
+     */
     public function getErrorCode(): string
     {
         return $this->errorCode;

--- a/src/Exceptions/InsufficientStockException.php
+++ b/src/Exceptions/InsufficientStockException.php
@@ -11,10 +11,11 @@ class InsufficientStockException extends BusinessLogicException
     /**
      * @param int $sku
      * @param string $responseBody
+     * @param int $statusCode
      */
-    public function __construct(int $sku, string $responseBody)
+    public function __construct(int $sku, string $responseBody, int $statusCode = 400)
     {
-        parent::__construct(Errors::INSUFFICIENT_STOCK, ['sku' => $sku], $responseBody);
+        parent::__construct(Errors::INSUFFICIENT_STOCK, ['sku' => $sku], $responseBody, $statusCode);
     }
 
     /**

--- a/src/Exceptions/MissingSkuException.php
+++ b/src/Exceptions/MissingSkuException.php
@@ -11,10 +11,11 @@ class MissingSkuException extends BusinessLogicException
     /**
      * @param int[] $skus
      * @param string $responseBody
+     * @param int $statusCode
      */
-    public function __construct(array $skus, string $responseBody)
+    public function __construct(array $skus, string $responseBody, int $statusCode = 400)
     {
-        parent::__construct(Errors::MISSING_SKU, ['skus' => $skus], $responseBody);
+        parent::__construct(Errors::MISSING_SKU, ['skus' => $skus], $responseBody, $statusCode);
     }
 
     /**

--- a/src/Exceptions/NoMatchingOrderException.php
+++ b/src/Exceptions/NoMatchingOrderException.php
@@ -11,9 +11,10 @@ class NoMatchingOrderException extends BusinessLogicException
     /**
      * @param array $context
      * @param string $responseBody
+     * @param int $statusCode
      */
-    public function __construct(array $context, string $responseBody)
+    public function __construct(array $context, string $responseBody, int $statusCode = 400)
     {
-        parent::__construct(Errors::NO_MATCHING_ORDER, $context, $responseBody);
+        parent::__construct(Errors::NO_MATCHING_ORDER, $context, $responseBody, $statusCode);
     }
 }

--- a/tests/Client/BusinessLogicExceptionFactoryTest.php
+++ b/tests/Client/BusinessLogicExceptionFactoryTest.php
@@ -10,7 +10,7 @@ use Huboo\Exceptions\NoMatchingOrderException;
 
 test('Error code matches exception type', function ($errorCode, $exceptionType, $context = []) {
     $factory = new BusinessLogicExceptionFactory();
-    $exception = $factory->make($errorCode, $context, '');
+    $exception = $factory->make($errorCode, $context, '', 400);
     expect($exception)->toBeInstanceOf($exceptionType);
 })->with([
     [Errors::NO_MATCHING_ORDER, NoMatchingOrderException::class],


### PR DESCRIPTION
Add 404 as a business logic exception type, this allows the exception to be caught generically and the code acted upon.